### PR TITLE
feat: adopt unified AppHeader (reference implementation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/hadoku-printtool",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Image manipulation tool for cropping, resizing, and collating images for print",
   "type": "module",
   "packageManager": "pnpm@11.5.0",
@@ -66,7 +66,7 @@
     "@vitejs/plugin-react": "^5.1.0",
     "@vitest/coverage-v8": "^4.1.7",
     "@wolffm/logger": "^1.1.0",
-    "@wolffm/task-ui-components": "^2.0.2",
+    "@wolffm/task-ui-components": "^2.1.0",
     "@wolffm/themes": "^3.0.2",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,11 +52,11 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
       '@wolffm/task-ui-components':
-        specifier: ^2.0.2
-        version: 2.0.2(react@19.2.3)
+        specifier: ^2.1.0
+        version: 2.1.0(react@19.2.3)
       '@wolffm/themes':
         specifier: ^3.0.2
-        version: 3.0.2(@wolffm/task-ui-components@2.0.2(react@19.2.3))(react@19.2.3)
+        version: 3.0.2(@wolffm/task-ui-components@2.1.0(react@19.2.3))(react@19.2.3)
       eslint:
         specifier: ^9.39.1
         version: 9.39.2
@@ -809,8 +809,8 @@ packages:
       react: ^18.0.0 || ^19.0.0
       zod: ^3.25.0 || ^4.0.0
 
-  '@wolffm/task-ui-components@2.0.2':
-    resolution: {integrity: sha512-F529/qfQr2Gwel+Q7N9lK5KI9dmrd8zjP/HtyvoOE/aXb9cSr/CLNioXum5Lp+E7Jiq3xfWK70OVUf1LUhApMw==, tarball: https://npm.pkg.github.com/download/@wolffm/task-ui-components/2.0.2/357aa11338ac81812c3f92135a481ff2ab3521f0}
+  '@wolffm/task-ui-components@2.1.0':
+    resolution: {integrity: sha512-Lz4LfJRVOt6UJQqhb8kg+6sX/rvamVmc35FE5VvbG/hdV+62Kdk+2eH04nzMY7MhyxAe2JhZq9lIIt9Iox8ISg==, tarball: https://npm.pkg.github.com/download/@wolffm/task-ui-components/2.1.0/f917554b4fdb9d856f343aad61c619175c2dcaae}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -2901,13 +2901,13 @@ snapshots:
       react: 19.2.3
       zod: 4.2.1
 
-  '@wolffm/task-ui-components@2.0.2(react@19.2.3)':
+  '@wolffm/task-ui-components@2.1.0(react@19.2.3)':
     dependencies:
       react: 19.2.3
 
-  '@wolffm/themes@3.0.2(@wolffm/task-ui-components@2.0.2(react@19.2.3))(react@19.2.3)':
+  '@wolffm/themes@3.0.2(@wolffm/task-ui-components@2.1.0(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@wolffm/task-ui-components': 2.0.2(react@19.2.3)
+      '@wolffm/task-ui-components': 2.1.0(react@19.2.3)
       react: 19.2.3
 
   acorn-jsx@5.3.2(acorn@8.15.0):

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useCallback, useEffect } from 'react'
-import { ConnectedThemePicker, LoadingSkeleton } from '@wolffm/task-ui-components'
+import { AppHeader, ConnectedThemePicker, LoadingSkeleton } from '@wolffm/task-ui-components'
 import { logger } from '@wolffm/logger/client'
 import { THEME_ICON_MAP } from '@wolffm/themes'
 import { useTheme } from './hooks/useTheme'
@@ -130,12 +130,10 @@ export default function App(props: PrintToolProps = {}) {
       data-dark-theme={isDarkTheme ? 'true' : 'false'}
     >
       <div className="printtool">
-        <header className="printtool__header">
-          <h1>Hadoku Print Tool</h1>
-
-          <div className="printtool__header-actions">
-            <ApiStatus status={apiStatus} onRetry={handleRetryHealth} />
-
+        <AppHeader
+          title="Hadoku Print Tool"
+          status={<ApiStatus status={apiStatus} onRetry={handleRetryHealth} />}
+          themePicker={
             <ConnectedThemePicker
               themeFamilies={THEME_FAMILIES}
               currentTheme={theme}
@@ -145,8 +143,8 @@ export default function App(props: PrintToolProps = {}) {
                 return Icon ? <Icon /> : null
               }}
             />
-          </div>
-        </header>
+          }
+        />
 
         <main className="printtool__content">
           <ModeSelector mode={state.mode} onModeChange={setMode} />

--- a/src/entry.tsx
+++ b/src/entry.tsx
@@ -5,6 +5,7 @@ import App from './App'
 import '@wolffm/themes/style.css'
 // REQUIRED: Import theme picker CSS
 import '@wolffm/task-ui-components/theme-picker.css'
+import '@wolffm/task-ui-components/app-header.css'
 import './styles/index.css'
 
 // Props interface for configuration from parent app

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -66,27 +66,9 @@
   padding: 2rem;
 }
 
-.printtool__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.printtool__header h1 {
-  margin: 0;
-  color: var(--color-primary);
-  font-size: var(--hdk-text-lg);
-  font-weight: var(--font-weight-bold, 700);
-}
-
-.printtool__header-actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
+/* Header now comes from the shared <AppHeader> (@wolffm/task-ui-components,
+ * app-header.css). The former .printtool__header / __header-actions rules were
+ * removed when this app adopted the unified header. */
 
 .printtool__content {
   padding: 1rem;


### PR DESCRIPTION
## What

printTool adopts the shared **`AppHeader`** from `@wolffm/task-ui-components` and becomes the **reference implementation** of the ecosystem header contract:

```
[ title (left) ] ————— <space> ————— [ ApiStatus · ThemePicker · Settings gear ] (right)
```

- Replaces the hand-rolled `.printtool__header` with `<AppHeader title="Hadoku Print Tool" status={<ApiStatus/>} themePicker={<ConnectedThemePicker/>} />`.
- The **settings gear** (unified per-user settings: tier · display name · content-visibility level · auth-key swap) is injected automatically by `AppHeader` — this was the one thing printTool was missing.
- The `ApiStatus` "API Online" indicator moves into the header's `status` slot (contract-acceptable).
- Removes the now-dead `.printtool__header` / `__header-actions` CSS.
- Bumps `@wolffm/task-ui-components` `^2.0.2 → ^2.1.0`; imports `app-header.css`.

## Why this app

printTool was already the closest to the contract — correct token usage, right-aligned actions, zero color debt. That made it the natural template. Every other app's adoption PR points here.

## Verification

Typecheck, `vite build` (app + worker), eslint, and the `@wolffm/themes` token check all pass locally against the published `2.1.0`.